### PR TITLE
Changed 'Faraday::Builder' to 'Faraday::RackBuilder' 

### DIFF
--- a/help_scout_docs.gemspec
+++ b/help_scout_docs.gemspec
@@ -17,14 +17,13 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.has_rdoc = true
-
   s.add_development_dependency "multi_json", "~> 1.8"
 
   s.add_development_dependency "rspec", "~> 3.0"
   s.add_development_dependency "webmock", "~> 1.15"
   s.add_development_dependency "vcr", "~> 2.9"
   s.add_development_dependency "json_spec", "~> 1.1"
+  s.add_development_dependency "pry", "~> 0.12.2"
 
   s.add_runtime_dependency "log4r", "~> 1.1"
   s.add_runtime_dependency "faraday_middleware", "~> 0.9"

--- a/lib/help_scout_docs/default.rb
+++ b/lib/help_scout_docs/default.rb
@@ -9,7 +9,7 @@ module HelpScoutDocs
 #     Faraday.default_adapter = :net_http_persistent
 
     ENDPOINT = 'https://docsapi.helpscout.net/v1/'
-    MIDDLEWARE = Faraday::Builder.new do |builder|
+    MIDDLEWARE = Faraday::RackBuilder.new do |builder|
       # Encode request params as "www-form-urlencoded"
       builder.use Faraday::Request::UrlEncoded
       # Parse JSON response bodies
@@ -45,7 +45,7 @@ module HelpScoutDocs
       # @note Faraday's middleware stack implementation is comparable to that of Rack middleware.  The order of middleware is important: the first middleware on the list wraps all others, while the last middleware is the innermost one.
       # @see https://github.com/technoweenie/faraday#advanced-middleware-usage
       # @see http://mislav.uniqpath.com/2011/07/faraday-advanced-http/
-      # @return [Faraday::Builder]
+      # @return [Faraday::RackBuilder]
       def middleware
         MIDDLEWARE
       end


### PR DESCRIPTION
Fixes #2 

We use this gem quite a bit and are getting the Faraday deprecation warning a fair amount so I decided to fix it.

I also added 'pry' to gemspec for tests as they wouldn't run otherwise and removed deprecated gem
configuration call to 'has_rdoc' as that was giving a deprecation warning as well.

Let me know if you have questsions or would like me to bump the version in this PR.